### PR TITLE
Add a way to pass configuration to activation

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -65,8 +65,11 @@ export class API implements DeviceTree {
     };
     version = 1;
 
+    /**
+     * Configuration provided by peer extension for the activation
+     */
     public activationCfg: {
-        [key: string]: string | null;
+        topdir: string | null;
     };
 
     constructor() {

--- a/src/api.ts
+++ b/src/api.ts
@@ -65,6 +65,10 @@ export class API implements DeviceTree {
     };
     version = 1;
 
+    public activationCfg: {
+        [key: string]: string | null;
+    };
+
     constructor() {
         dts.parser.onStable(ctx => {
             this._changeEmitter.fire(packCtx(ctx));
@@ -88,7 +92,7 @@ export class API implements DeviceTree {
         return Promise.reject();
     }
 
-    setZephyrBase(uri: vscode.Uri) {
+    async setZephyrBase(uri: vscode.Uri): Promise<void> {
         return zephyr.setZephyrBase(uri);
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1616,16 +1616,21 @@ class DTSEngine implements
 export async function activate(
     context: vscode.ExtensionContext
 ): Promise<API> {
-    await zephyr.activate(context);
-    await typeLoader.activate(context);
+    const api = new API();
 
-    const engine = new DTSEngine();
-    await engine.loadCtxs();
-    await dts.parser.activate(context);
-    engine.activate(context);
-    treeView.activate(context);
+    // deferred activation in case activationCfg is set by peer extension synchronously
+    setTimeout(async () => {
+        await zephyr.activate(api.activationCfg.topdir);
+        await typeLoader.activate(context);
 
-    return new API();
+        const engine = new DTSEngine();
+        await engine.loadCtxs();
+        await dts.parser.activate(context);
+        engine.activate(context);
+        treeView.activate(context);
+    }, 1);
+
+    return api;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/src/zephyr.ts
+++ b/src/zephyr.ts
@@ -255,8 +255,11 @@ export async function selectBoard(prompt = 'Set board'): Promise<Board> {
         .then(board => board['board']);
 }
 
-export function activate(ctx: vscode.ExtensionContext) {
+export function activate(topdir?: string) {
     config.onChange('modules', () => (modules = resolveModules()));
+    if (topdir) {
+        return setZephyrBase(vscode.Uri.joinPath(vscode.Uri.file(topdir), 'zephyr'));
+    }
     config.onChange('zephyr', findZephyr);
     return findZephyr();
 }


### PR DESCRIPTION
This PR adds a configuration object to the extension wrapper API, so a peer extension can pass initial configuration to this extension used at activation time. For this reason the activation itself is deferred by 1 ms, so the configuration can be synchronously set.

This configuration currently passes topdir, that is the parent directory of zephyr(Base), so this extension does not need to find it itself.