### PR TITLE
Handle activationCfg === undefined

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -65,13 +65,6 @@ export class API implements DeviceTree {
     };
     version = 1;
 
-    /**
-     * Configuration provided by peer extension for the activation
-     */
-    public activationCfg: {
-        topdir: string | null;
-    };
-
     constructor() {
         dts.parser.onStable(ctx => {
             this._changeEmitter.fire(packCtx(ctx));

--- a/src/api.ts
+++ b/src/api.ts
@@ -65,10 +65,21 @@ export class API implements DeviceTree {
     };
     version = 1;
 
+    /**
+     * Configuration provided by peer extension for the activation
+     */
+    public activationCfg: {
+        zephyrBase?: string;
+    };
+
     constructor() {
         dts.parser.onStable(ctx => {
             this._changeEmitter.fire(packCtx(ctx));
         });
+
+        this.activationCfg = {
+            zephyrBase: undefined
+        };
     }
 
     async addContext(boardUri: vscode.Uri, overlays: vscode.Uri[] = [], name?: string): Promise<Context> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1620,7 +1620,7 @@ export async function activate(
 
     // deferred activation in case activationCfg is set by peer extension synchronously
     setTimeout(async () => {
-        await zephyr.activate(api.activationCfg.topdir);
+        await zephyr.activate(api.activationCfg?.topdir);
         await typeLoader.activate(context);
 
         const engine = new DTSEngine();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1618,17 +1618,15 @@ export async function activate(
 ): Promise<API> {
     const api = new API();
 
-    // deferred activation in case activationCfg is set by peer extension synchronously
-    setTimeout(async () => {
-        await zephyr.activate(api.activationCfg?.topdir);
-        await typeLoader.activate(context);
+    await zephyr.activate();
+    await typeLoader.activate(context);
 
-        const engine = new DTSEngine();
-        await engine.loadCtxs();
-        await dts.parser.activate(context);
-        engine.activate(context);
-        treeView.activate(context);
-    }, 1);
+    const engine = new DTSEngine();
+    await engine.loadCtxs();
+    await dts.parser.activate(context);
+    engine.activate(context);
+    treeView.activate(context);
+  
 
     return api;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1619,7 +1619,7 @@ export async function activate(
     const api = new API();
 
     // deferred activation in case activationCfg is set by peer extension synchronously
-    setTimeout(async () => {        
+    setTimeout(async () => {
         await zephyr.activate(api.activationCfg?.zephyrBase);
         await typeLoader.activate(context);
 
@@ -1629,7 +1629,7 @@ export async function activate(
         engine.activate(context);
         treeView.activate(context);
     }, 1);
-  
+
     return api;
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1618,16 +1618,18 @@ export async function activate(
 ): Promise<API> {
     const api = new API();
 
-    await zephyr.activate();
-    await typeLoader.activate(context);
+    // deferred activation in case activationCfg is set by peer extension synchronously
+    setTimeout(async () => {        
+        await zephyr.activate(api.activationCfg?.zephyrBase);
+        await typeLoader.activate(context);
 
-    const engine = new DTSEngine();
-    await engine.loadCtxs();
-    await dts.parser.activate(context);
-    engine.activate(context);
-    treeView.activate(context);
+        const engine = new DTSEngine();
+        await engine.loadCtxs();
+        await dts.parser.activate(context);
+        engine.activate(context);
+        treeView.activate(context);
+    }, 1);
   
-
     return api;
 }
 

--- a/src/zephyr.ts
+++ b/src/zephyr.ts
@@ -255,11 +255,8 @@ export async function selectBoard(prompt = 'Set board'): Promise<Board> {
         .then(board => board['board']);
 }
 
-export function activate(topdir?: string) {
+export function activate() {
     config.onChange('modules', () => (modules = resolveModules()));
-    if (topdir) {
-        return setZephyrBase(vscode.Uri.joinPath(vscode.Uri.file(topdir), 'zephyr'));
-    }
     config.onChange('zephyr', findZephyr);
     return findZephyr();
 }

--- a/src/zephyr.ts
+++ b/src/zephyr.ts
@@ -255,8 +255,11 @@ export async function selectBoard(prompt = 'Set board'): Promise<Board> {
         .then(board => board['board']);
 }
 
-export function activate() {
+export function activate(zephyrBase?: string) {
     config.onChange('modules', () => (modules = resolveModules()));
+    if (zephyrBase) {
+        return setZephyrBase(vscode.Uri.file(zephyrBase));
+    }
     config.onChange('zephyr', findZephyr);
     return findZephyr();
 }


### PR DESCRIPTION
If activationCfg is undefined, a unhandled promise warning is shown with "Cannot access property of undefined". I suspect  a race condition. Maybe we shouldn't try to set topdir synchronously with the activate call?