### PR TITLE
Avoid activation race when extension is activated from nrf-connect

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -8,8 +8,8 @@ import * as dts from "./dts";
 import { DeviceTree, Context, InfoItem, File } from "../api";
 import { TreeInfoItem, iconPath, treeView } from "./treeView";
 import { DTSDocumentProvider } from "./compiledOutput";
-import { typeLoader } from "./types";
 import * as zephyr from './zephyr';
+import { secondaryActivate } from "./extension";
 
 function packFile(file: dts.DTSFile): File {
     const getIncludes = (uri: vscode.Uri): vscode.Uri[] => {
@@ -80,6 +80,10 @@ export class API implements DeviceTree {
         this.activationCfg = {
             zephyrBase: undefined
         };
+    }
+
+    async secondaryActivate(): Promise<void> {
+        await secondaryActivate();
     }
 
     async addContext(boardUri: vscode.Uri, overlays: vscode.Uri[] = [], name?: string): Promise<Context> {


### PR DESCRIPTION
In this PR the activation is moved to _secondaryActivate()_ function which is either called directly when the extension is independently installed, or if _nordic-semiconductor.nrf-connect_ extension is present it will call the secondary activation via the api.