### PR TITLE
Byte arrays: support comments and long values

### DIFF
--- a/src/dts.ts
+++ b/src/dts.ts
@@ -323,7 +323,7 @@ export class BytestringValue extends PropertyValue {
     }
 
     toString() {
-        return `[ ${this.val.map((v) => (v < 0x10 ? '0' : '') + v.toString(16)).join(' ')} ]`;
+        return `[${this.val.map((v) => (v < 0x10 ? '0' : '') + v.toString(16)).join(' ')}]`;
     }
 }
 
@@ -502,7 +502,27 @@ export class Property {
             return 'true';
         }
 
-        const values = this.value.map((v) => v.toString());
+        /* Split entries at spaces if they're too long */
+        const values = this.value.map((v) => {
+            const lines = new Array<string>();
+            let line: RegExpMatchArray;
+
+            let value = v.toString();
+            while (
+                value.length > 80 - indent &&
+                (line = value.match(new RegExp(`^.{1,${80 - indent}}\\s`)))
+            ) {
+                lines.push(line[0].trim());
+                value = value.slice(line[0].length);
+            }
+
+            if (value) {
+                lines.push(value);
+            }
+
+            return lines.join('\n' + ' '.repeat(indent + 1));
+        });
+
         if (values.length > 1 && indent + values.join(', ').length > 80) {
             return values.join(',\n' + ' '.repeat(indent));
         }

--- a/src/dts.ts
+++ b/src/dts.ts
@@ -303,8 +303,15 @@ export class BytestringValue extends PropertyValue {
         const start = state.freeze();
         const bytes = new Array<number>();
         let match: RegExpMatchArray;
-        while ((match = state.match(/^\s*([\da-fA-F]{2})/))) {
-            bytes.push(parseInt(match[1], 16));
+        while (state.skipWhitespace()) {
+            state.skipComment();
+
+            match = state.match(/^[\da-fA-F]{2}/);
+            if (!match) {
+                break;
+            }
+
+            bytes.push(parseInt(match[0], 16));
         }
 
         if (!state.match(/^\s*]/)) {
@@ -1937,16 +1944,7 @@ export class Parser {
         let requireSemicolon = false;
         let labels = new Array<string>();
         while (state.skipWhitespace()) {
-            const blockComment = state.match(/^\/\*[\s\S]*?\*\//);
-            if (blockComment) {
-                continue;
-            }
-
-            const comment = state.match(/^\/\/.*/);
-            if (comment) {
-                continue;
-            }
-
+            state.skipComment();
             if (requireSemicolon) {
                 requireSemicolon = false;
                 const semicolon = state.match(/^;/);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -151,6 +151,12 @@ export class ParserState {
         return !this.eof();
     }
 
+    skipComment() {
+        do {
+            this.skipWhitespace();
+        } while (this.match(/^\/\*[\s\S]*?\*\//) || this.match(/^\/\/.*/));
+    }
+
     skipToken() {
         const match = this.match(this.token);
         if (!match) {


### PR DESCRIPTION
Fixes a bug where byte arrays would break the parser if the value contained comments. 
Additionally formats the byte arrays to be split across multiple lines in the compiled output if they're longer than 80 characters.